### PR TITLE
Fix the error handler in .checkTable

### DIFF
--- a/src/relational.js
+++ b/src/relational.js
@@ -275,7 +275,7 @@ module.exports = function (name, schema, options) {
 
     _private.checkTable = (table, tableNames) => {
         for (var key in table) {
-            if (!table[key].type) {
+            if (!Object.prototype.hasOwnProperty.call(table[key].type)) {
                 throw new Error(`'${table}' '${key}' has undefined type`)
             }
             const s = table[key].type.split(' ')


### PR DESCRIPTION
It used to do a check as !object.field which doesn't work.
You actually have to ask the object if the key exists.